### PR TITLE
Stabilize AppSession flow tests in CI

### DIFF
--- a/LoveSavingTests/ViewModels/AppSessionFlowTests.swift
+++ b/LoveSavingTests/ViewModels/AppSessionFlowTests.swift
@@ -97,7 +97,7 @@ final class AppSessionFlowTests: XCTestCase {
 
     private func waitUntil(
         _ description: String,
-        timeoutNanoseconds: UInt64 = 1_000_000_000,
+        timeoutNanoseconds: UInt64 = 5_000_000_000,
         condition: @escaping @MainActor () -> Bool
     ) async {
         let clock = ContinuousClock()
@@ -106,7 +106,7 @@ final class AppSessionFlowTests: XCTestCase {
             if condition() {
                 return
             }
-            await Task.yield()
+            try? await Task.sleep(nanoseconds: 10_000_000)
         }
 
         XCTFail("Timed out waiting for condition: \(description)")


### PR DESCRIPTION
### Motivation
- Reduce flakiness in async UI tests where auth/invite/group state propagation can be slower on CI by increasing the wait window and avoiding tight scheduler-yield loops.

### Description
- In `LoveSavingTests/ViewModels/AppSessionFlowTests.swift` increase `waitUntil` default timeout from `1_000_000_000` to `5_000_000_000` nanoseconds and replace `await Task.yield()` with `try? await Task.sleep(nanoseconds: 10_000_000)` to reduce scheduler churn.

### Testing
- Ran `swift --version` successfully and attempted `xcodebuild -list -project LoveSaving.xcodeproj` which failed in this environment because `xcodebuild` is unavailable, so full unit test execution was not possible here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a84827eeb8832e95df5f90d24fa0f5)