### PR TITLE
Fix Firestore invite query to respect rules

### DIFF
--- a/Firebase/functions/package-lock.json
+++ b/Firebase/functions/package-lock.json
@@ -1105,7 +1105,6 @@
       "resolved": "https://registry.npmjs.org/firebase-admin/-/firebase-admin-12.7.0.tgz",
       "integrity": "sha512-raFIrOyTqREbyXsNkSHyciQLfv8AUZazehPaQS1lZBSCDYW74FYXU0nQZa3qHI4K+hawohlDbywZ4+qce9YNxA==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@fastify/busboy": "^3.0.0",
         "@firebase/database-compat": "1.0.8",


### PR DESCRIPTION
Fix invite query so it matches Firestore security rules.
Also keeps GoogleService-Info.plist ignored locally.