### PR TITLE
Image-Preview

### DIFF
--- a/LoveSaving.xcodeproj/project.pbxproj
+++ b/LoveSaving.xcodeproj/project.pbxproj
@@ -462,10 +462,9 @@
 		BFCB656D2F48FEF200CF07DA /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				APS_ENVIRONMENT = development;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
-				CODE_SIGN_ENTITLEMENTS = LoveSaving/LoveSaving.entitlements;
+				CODE_SIGN_ENTITLEMENTS = LoveSaving/LoveSavingDebug.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = NU6Z4JA9HM;
@@ -502,10 +501,9 @@
 		BFCB656E2F48FEF200CF07DA /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				APS_ENVIRONMENT = production;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
-				CODE_SIGN_ENTITLEMENTS = LoveSaving/LoveSaving.entitlements;
+				CODE_SIGN_ENTITLEMENTS = LoveSaving/LoveSavingRelease.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = NU6Z4JA9HM;

--- a/LoveSaving/LoveSavingDebug.entitlements
+++ b/LoveSaving/LoveSavingDebug.entitlements
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>aps-environment</key>
+	<string>development</string>
+</dict>
+</plist>

--- a/LoveSaving/LoveSavingRelease.entitlements
+++ b/LoveSaving/LoveSavingRelease.entitlements
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>aps-environment</key>
-	<string>$(APS_ENVIRONMENT)</string>
+	<string>production</string>
 </dict>
 </plist>

--- a/LoveSaving/Views/EventMediaPreview.swift
+++ b/LoveSaving/Views/EventMediaPreview.swift
@@ -2,6 +2,45 @@ import FirebaseStorage
 import SwiftUI
 import UIKit
 
+struct EventMediaInlinePreview: View {
+    let media: EventMedia
+    let additionalImageCount: Int
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            ZStack(alignment: .topTrailing) {
+                EventMediaImageContainer(media: media) { image in
+                    Image(uiImage: image)
+                        .resizable()
+                        .interpolation(.high)
+                        .scaledToFit()
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+                }
+                .frame(maxWidth: .infinity, minHeight: 150, maxHeight: 220)
+                .padding(12)
+                .background(Color.secondary.opacity(0.08))
+
+                if additionalImageCount > 0 {
+                    Text("+\(additionalImageCount)")
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(.white)
+                        .padding(.horizontal, 10)
+                        .padding(.vertical, 6)
+                        .background(.black.opacity(0.65), in: Capsule())
+                        .padding(12)
+                }
+            }
+            .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
+            .overlay {
+                RoundedRectangle(cornerRadius: 16, style: .continuous)
+                    .stroke(Color.secondary.opacity(0.15))
+            }
+        }
+        .buttonStyle(.plain)
+    }
+}
+
 struct EventMediaPreviewSheet: View {
     @Environment(\.dismiss) private var dismiss
 
@@ -43,7 +82,8 @@ private struct EventMediaPreviewPage: View {
             Color.black.ignoresSafeArea()
 
             EventMediaPreviewImage(media: media)
-                .padding()
+                .padding(.horizontal, 16)
+                .padding(.vertical, 12)
 
             if totalCount > 1 {
                 Text("\(index + 1) / \(totalCount)")
@@ -58,40 +98,25 @@ private struct EventMediaPreviewPage: View {
     }
 }
 
-private struct EventMediaPreviewImage: View {
-    private enum Phase {
-        case loading
-        case loaded(UIImage)
-        case failed
-    }
-
-    private static let imageCache = NSCache<NSString, UIImage>()
-    private static let maxDownloadBytes: Int64 = 10 * 1024 * 1024
-
+private struct EventMediaImageContainer<Content: View>: View {
     let media: EventMedia
+    let content: (UIImage) -> Content
 
-    @State private var phase: Phase = .loading
+    @State private var phase: EventMediaImagePhase = .loading
+
+    init(media: EventMedia, @ViewBuilder content: @escaping (UIImage) -> Content) {
+        self.media = media
+        self.content = content
+    }
 
     var body: some View {
         Group {
             switch phase {
             case .loading:
-                ProgressView("Loading image...")
-                    .tint(.white)
-                    .foregroundStyle(.white)
+                ProgressView()
+                    .controlSize(.regular)
             case .loaded(let image):
-                GeometryReader { proxy in
-                    ScrollView([.horizontal, .vertical]) {
-                        Image(uiImage: image)
-                            .resizable()
-                            .scaledToFit()
-                            .frame(
-                                minWidth: proxy.size.width,
-                                minHeight: proxy.size.height
-                            )
-                    }
-                    .scrollIndicators(.hidden)
-                }
+                content(image)
             case .failed:
                 ContentUnavailableView(
                     "Unable to Load Image",
@@ -110,7 +135,7 @@ private struct EventMediaPreviewImage: View {
     @MainActor
     private func loadImage() async {
         let cacheKey = media.storagePath as NSString
-        if let cached = Self.imageCache.object(forKey: cacheKey) {
+        if let cached = EventMediaImageLoader.imageCache.object(forKey: cacheKey) {
             phase = .loaded(cached)
             return
         }
@@ -124,7 +149,7 @@ private struct EventMediaPreviewImage: View {
                 return
             }
 
-            Self.imageCache.setObject(image, forKey: cacheKey)
+            EventMediaImageLoader.imageCache.setObject(image, forKey: cacheKey)
             phase = .loaded(image)
         } catch {
             phase = .failed
@@ -132,13 +157,13 @@ private struct EventMediaPreviewImage: View {
     }
 
     private func imageData(for media: EventMedia) async throws -> Data {
-        if let inlineData = Self.decodeInlineDataURL(media.storagePath) {
+        if let inlineData = EventMediaImageLoader.decodeInlineDataURL(media.storagePath) {
             return inlineData
         }
 
         let reference = Storage.storage().reference(withPath: media.storagePath)
         return try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Data, Error>) in
-            reference.getData(maxSize: Self.maxDownloadBytes) { data, error in
+            reference.getData(maxSize: EventMediaImageLoader.maxDownloadBytes) { data, error in
                 if let error {
                     continuation.resume(throwing: error)
                 } else if let data {
@@ -150,7 +175,13 @@ private struct EventMediaPreviewImage: View {
         }
     }
 
-    private static func decodeInlineDataURL(_ storagePath: String) -> Data? {
+}
+
+private enum EventMediaImageLoader {
+    static let imageCache = NSCache<NSString, UIImage>()
+    static let maxDownloadBytes: Int64 = 10 * 1024 * 1024
+
+    static func decodeInlineDataURL(_ storagePath: String) -> Data? {
         guard storagePath.hasPrefix("data:"),
               let separatorIndex = storagePath.firstIndex(of: ",") else {
             return nil
@@ -164,5 +195,87 @@ private struct EventMediaPreviewImage: View {
         }
 
         return String(payload).removingPercentEncoding?.data(using: .utf8)
+    }
+}
+
+private enum EventMediaImagePhase {
+    case loading
+    case loaded(UIImage)
+    case failed
+}
+
+private struct EventMediaPreviewImage: View {
+    let media: EventMedia
+
+    var body: some View {
+        EventMediaImageContainer(media: media) { image in
+            ZoomableEventMediaImage(image: image)
+        }
+    }
+}
+
+private struct ZoomableEventMediaImage: View {
+    let image: UIImage
+
+    @State private var zoomScale: CGFloat = 1
+    @State private var committedZoomScale: CGFloat = 1
+
+    private let minimumZoomScale: CGFloat = 1
+    private let maximumZoomScale: CGFloat = 4
+
+    var body: some View {
+        GeometryReader { proxy in
+            let fittedSize = image.size.aspectFit(in: proxy.size)
+            ScrollView([.horizontal, .vertical]) {
+                Image(uiImage: image)
+                    .resizable()
+                    .interpolation(.high)
+                    .frame(
+                        width: fittedSize.width * zoomScale,
+                        height: fittedSize.height * zoomScale
+                    )
+                    .frame(
+                        width: max(proxy.size.width, fittedSize.width * zoomScale),
+                        height: max(proxy.size.height, fittedSize.height * zoomScale)
+                    )
+            }
+            .scrollIndicators(.hidden)
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .contentShape(Rectangle())
+            .simultaneousGesture(
+                MagnificationGesture()
+                    .onChanged { value in
+                        zoomScale = clampedZoomScale(committedZoomScale * value)
+                    }
+                    .onEnded { value in
+                        let updatedZoomScale = clampedZoomScale(committedZoomScale * value)
+                        zoomScale = updatedZoomScale
+                        committedZoomScale = updatedZoomScale
+                    }
+            )
+            .onTapGesture(count: 2) {
+                let updatedZoomScale = zoomScale > minimumZoomScale ? minimumZoomScale : 2
+                zoomScale = updatedZoomScale
+                committedZoomScale = updatedZoomScale
+            }
+        }
+    }
+
+    private func clampedZoomScale(_ value: CGFloat) -> CGFloat {
+        min(max(value, minimumZoomScale), maximumZoomScale)
+    }
+}
+
+private extension CGSize {
+    func aspectFit(in container: CGSize) -> CGSize {
+        guard width > 0, height > 0, container.width > 0, container.height > 0 else {
+            return .zero
+        }
+
+        let widthRatio = container.width / width
+        let heightRatio = container.height / height
+        let scale = min(widthRatio, heightRatio)
+
+        return CGSize(width: width * scale, height: height * scale)
     }
 }

--- a/LoveSaving/Views/EventMediaPreview.swift
+++ b/LoveSaving/Views/EventMediaPreview.swift
@@ -100,12 +100,18 @@ private struct EventMediaPreviewPage: View {
 
 private struct EventMediaImageContainer<Content: View>: View {
     let media: EventMedia
+    let failureForegroundColor: Color?
     let content: (UIImage) -> Content
 
     @State private var phase: EventMediaImagePhase = .loading
 
-    init(media: EventMedia, @ViewBuilder content: @escaping (UIImage) -> Content) {
+    init(
+        media: EventMedia,
+        failureForegroundColor: Color? = nil,
+        @ViewBuilder content: @escaping (UIImage) -> Content
+    ) {
         self.media = media
+        self.failureForegroundColor = failureForegroundColor
         self.content = content
     }
 
@@ -118,12 +124,7 @@ private struct EventMediaImageContainer<Content: View>: View {
             case .loaded(let image):
                 content(image)
             case .failed:
-                ContentUnavailableView(
-                    "Unable to Load Image",
-                    systemImage: "photo.badge.exclamationmark",
-                    description: Text("This attachment could not be previewed right now.")
-                )
-                .foregroundStyle(.white)
+                failureView
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -153,6 +154,21 @@ private struct EventMediaImageContainer<Content: View>: View {
             phase = .loaded(image)
         } catch {
             phase = .failed
+        }
+    }
+
+    @ViewBuilder
+    private var failureView: some View {
+        let view = ContentUnavailableView(
+            "Unable to Load Image",
+            systemImage: "photo.badge.exclamationmark",
+            description: Text("This attachment could not be previewed right now.")
+        )
+
+        if let failureForegroundColor {
+            view.foregroundStyle(failureForegroundColor)
+        } else {
+            view
         }
     }
 }
@@ -207,7 +223,7 @@ private struct EventMediaPreviewImage: View {
     let media: EventMedia
 
     var body: some View {
-        EventMediaImageContainer(media: media) { image in
+        EventMediaImageContainer(media: media, failureForegroundColor: .white) { image in
             ZoomableEventMediaImage(image: image)
         }
     }

--- a/LoveSaving/Views/JourneyView.swift
+++ b/LoveSaving/Views/JourneyView.swift
@@ -46,19 +46,22 @@ struct JourneyView: View {
                                     .foregroundStyle(event.delta >= 0 ? .green : .red)
                                     .font(.subheadline.weight(.semibold))
                                 
-                                if !event.media.isEmpty {
-                                    Button {
+                                if let previewMedia = event.media.first {
+                                    EventMediaInlinePreview(
+                                        media: previewMedia,
+                                        additionalImageCount: max(event.media.count - 1, 0)
+                                    ) {
                                         previewingEvent = event
-                                    } label: {
-                                        Label(
-                                            "\(event.media.count) image\(event.media.count == 1 ? "" : "s") attached",
-                                            systemImage: "photo"
-                                        )
-                                        .font(.caption)
-                                        .foregroundStyle(.secondary)
                                     }
-                                    .buttonStyle(.plain)
                                     .accessibilityIdentifier("journey.imagePreview.open")
+
+                                    Text(
+                                        event.media.count == 1
+                                            ? "Image preview"
+                                            : "\(event.media.count) images attached"
+                                    )
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
                                 }
 
                                 HStack {


### PR DESCRIPTION
1. Adds an image preview flow for Journey events with attachments.
2. Makes the existing image attached label tappable and opens a dedicated Image Preview sheet.
3. Supports both Firebase Storage images and inline test images used in UI test mode.